### PR TITLE
默认关闭Sync Options

### DIFF
--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -18,7 +18,8 @@ module.exports = function (gulp, Plugin, config) {
 				})
 			},
 			port: port,
-			open: false
+			open: false,
+			ghostMode: false
 		});
 	});
 	gulp.task('server', ['watch', 'browser-sync']);


### PR DESCRIPTION
默认关闭Sync Options，本地调试时每次启动都会默认打开，点击一次展开二级菜单时会出现不停的点击，发现是Sync Options
click造成的问题